### PR TITLE
Несоответствие параметров с методом родительского класса

### DIFF
--- a/common/classes/modules/blog/entity/BlogType.entity.class.php
+++ b/common/classes/modules/blog/entity/BlogType.entity.class.php
@@ -53,7 +53,7 @@ class ModuleBlog_EntityBlogType extends Entity {
         return $sValue;
     }
 
-    public function getProp($sKey) {
+    public function getProp($sKey, $xDefault = NULL) {
 
         if ($sKey == 'type_name' || $sKey == 'type_description') {
             $sValue = parent::getProp($sKey);


### PR DESCRIPTION
<b>Дает ошибку:</b> 
<em>"E_STRICT [2048] Declaration of ModuleBlog_EntityBlogType::getProp() should be compatible with Entity::getProp($sKey, $xDefault = NULL)
See details in error.log"</em>

Параметры метода приведены в соответствие с параметрами метода в родительском классе.
