### PR TITLE
Update ActionContent.class.php

### DIFF
--- a/common/classes/actions/ActionContent.class.php
+++ b/common/classes/actions/ActionContent.class.php
@@ -300,7 +300,7 @@ class ActionContent extends Action {
         $this->Viewer_Assign('aBlogsAllow', $this->Blog_GetBlogsAllowByUser($this->oUserCurrent));
         $this->Viewer_Assign('bEditDisabled', false);
         $this->Viewer_AddHtmlTitle(
-            $this->Lang_Get('topic_topic_create') . ' ' . mb_strtolower($this->oContentType->getContentTitle())
+            $this->Lang_Get('topic_topic_create') . ' ' . mb_strtolower($this->oContentType->getContentTitle(), 'UTF-8')
         );
         if (!is_numeric(getRequest('topic_id'))) {
             $_REQUEST['topic_id'] = '';


### PR DESCRIPTION
Если на сервере не установлена кодировка по умолчанию, то вместо слова в нижнем регистре выводятся крокозябры (�����). Для надежности все же лучше явно указать кодировку.
UPD
Кодировка сервера или заданная кодировка в .htaccess не при чем, я просто запамятовал - mb_strtolower применяется к символам не на латинице только с явным указанием кодировки.
