### PR TITLE
Дополнительный Event для ActionError

### DIFF
--- a/common/classes/actions/ActionError.class.php
+++ b/common/classes/actions/ActionError.class.php
@@ -53,6 +53,7 @@ class ActionError extends Action {
      */
     protected function RegisterEvent() {
         $this->AddEvent('index', 'EventError');
+        $this->AddEvent('notice', 'EventNotice');
         $this->AddEventPreg('/^\d{3}$/i', 'EventError');
     }
 
@@ -81,6 +82,12 @@ class ActionError extends Action {
         $this->Viewer_AddHtmlTitle($this->Lang_Get('error'));
         $this->SetTemplateAction('index');
     }
+
+    protected function EventNotice() {
+        $this->Viewer_AddHtmlTitle($this->Lang_Get('attention'));
+        $this->SetTemplateAction('index');
+    }
+
 }
 
 // EOF

--- a/common/templates/skin/synio/actions/ActionBlogs/index.tpl
+++ b/common/templates/skin/synio/actions/ActionBlogs/index.tpl
@@ -10,14 +10,7 @@
 
 <form action="" method="POST" id="form-blogs-search" onsubmit="return false;" class="search-item">
     <div class="search-input-wrapper">
-<<<<<<< HEAD
         <input type="text" placeholder="{$aLang.blogs_search_title_hint}" autocomplete="off" name="blog_title" class="input-text" value="" onkeyup="ls.timer.run(ls.blog.searchBlogs,'blogs_search',['form-blogs-search'],1000);">
-=======
-        <input type="text" placeholder="{$aLang.blogs_search_title_hint}" autocomplete="off" name="blog_title"
-               class="input-text" value=""
-               onkeyup="ls.timer.run(ls.blog.searchBlogs,'blogs_search',['form-blogs-search'],1000);">
-        <input type="hidden" name="blog_type" value="{$sShow}">
->>>>>>> 4d19312df9d83a38f34b9b7e2e58fe66dcf9679a
         <div class="input-submit" onclick="jQuery('#form-blogs-search').submit()"></div>
     </div>
 </form>


### PR DESCRIPTION
Предлагаю добавить дополнительный Event для ActionError который будет отвечать за вывод предупреждений (а не ошибок). Очень приготидся к примеру в плагине openoid который при любой (даже позитивной) операции переходит на Router::Action('error') который в свою очередь показывает пользователям ошибку даже при условии что эта операция не ошибочна.
