### PR TITLE
Повторная инициализация сущности

### DIFF
--- a/engine/classes/core/Engine.class.php
+++ b/engine/classes/core/Engine.class.php
@@ -927,7 +927,7 @@ class Engine extends LsObject {
 
         $sClass = self::GetEntityClass($sName);
         $oEntity = new $sClass($aParams);
-        $oEntity->Init();
+        //$oEntity->Init();
         return $oEntity;
     }
 


### PR DESCRIPTION
В конструкторе абстрактного класса сущности (/engine/classes/abstract/Entity.class.php) уже вызывается метод $this->Init(). Повторный вызов Init приводит к тому, что в сущности ModuleUser_EntityUser дублируются и повторно выполняются валидаторы полей.
