### PR TITLE
Выбор уровня конфига в функции-плагине Smarty

### DIFF
--- a/engine/classes/modules/viewer/plugs/function.cfg.php
+++ b/engine/classes/modules/viewer/plugs/function.cfg.php
@@ -36,10 +36,14 @@ function smarty_function_cfg($aParams, $oSmartyTemplate) {
         $aParams['default'] = null;
     }
 
+    if (!isset($aParams['level'])) {
+        $aParams['level'] = null;
+    }
+
     /**
      * Возвращаем значение из конфигурации
      */
-    $xResult = Config::Get($aParams['name'], $aParams['instance']);
+    $xResult = Config::Get($aParams['name'], $aParams['instance'], $aParams['level']);
     return is_null($xResult) ? $aParams['default'] : $xResult;
 }
 


### PR DESCRIPTION
Возникла из необходимости получения в шаблоне конфигурационного параметра темы. Конфиг темы загружается с уровнем _Config::LEVEL_SKIN_ и из шаблонов темы недоступен. Данная правка решает эту проблему. Теперь доступ к конфигу по уровням из шаблона возможен таким образом:

```
{if {cfg name="view.mytheme.say_hello" level=Config::LEVEL_SKIN}
     <span>hello</span>
{/if}
```
