### PR TITLE
Update ActionContent.class.php

### DIFF
--- a/common/classes/actions/ActionContent.class.php
+++ b/common/classes/actions/ActionContent.class.php
@@ -837,11 +837,12 @@ class ActionContent extends Action {
                     );
                     return;
                 }
-				$this->Message_AddError($this->Lang_Get('system_error'), $this->Lang_Get('error'));
+		$this->Message_AddError($this->Lang_Get('system_error'), $this->Lang_Get('error'));
+		return;
             }
-            $this->Message_AddError($this->Lang_Get('system_error'), $this->Lang_Get('error'));
+            $this->Topic_DeleteTopicPhoto($oPhoto);
+            $this->Message_AddNotice($this->Lang_Get('topic_photoset_photo_deleted'), $this->Lang_Get('attention'));
             return;
-            
         }
         $this->Message_AddError($this->Lang_Get('system_error'), $this->Lang_Get('error'));
         return;


### PR DESCRIPTION
Неправильная обработка вывода сообщения об успехе или ошибке при удалении картинки из фотосета.
Второй коммит - исправил свою ошибку в условии, когда создается новый топик и его ID еще нет.
