### PR TITLE
Update Topic.class.php

### DIFF
--- a/common/classes/modules/topic/Topic.class.php
+++ b/common/classes/modules/topic/Topic.class.php
@@ -720,9 +720,11 @@ class ModuleTopic extends Module {
         /**
          * Удаляем фото у топика фотосета
          */
-        if ($aPhotos = $this->getPhotosByTopicId($aTopicsId)) {
-            foreach ($aPhotos as $oPhoto) {
-                $this->deleteTopicPhoto($oPhoto);
+        foreach ($aTopicsId as $iTopicId) {
+            if ($aPhotos = $this->getPhotosByTopicId($iTopicId)) {
+                foreach ($aPhotos as $oPhoto) {
+                    $this->deleteTopicPhoto($oPhoto);
+                }
             }
         }
         /**


### PR DESCRIPTION
Ошибка удаления строк из таблицы  _topic _photo в БД. Метод getPhotosByTopicId ($iTopicId, $iFromId, $iCount) класса ModuleTopic_MapperTopic сейчас получает в первом параметре массив, а должен получать целое число. Из-за этого не происходит удаления соответствующих строк в БД.
