### PR TITLE
Возвращение несуществующей переменной

### DIFF
--- a/common/classes/modules/notify/Notify.class.php
+++ b/common/classes/modules/notify/Notify.class.php
@@ -595,7 +595,7 @@ class ModuleNotify extends Module {
     public function GetTemplatePath($sName, $sPluginName = null) {
 
         $sCacheKey = 'template_path_' . $sName . '-' . $sPluginName;
-        if (false === ($data = $this->Cache_Get($sCacheKey, 'tmp'))) {
+        if (false === ($sResult = $this->Cache_Get($sCacheKey, 'tmp'))) {
             $bFound = false;
             if ($sPluginName) {
                 $sPluginName = preg_match('/^Plugin([\w]+)(_[\w]+)?$/Ui', $sPluginName, $aMatches)


### PR DESCRIPTION
В случае наличия кэша метод возвращает $sResult. Но такой переменной нет, поскольку при проверке кэша результат этой проверки возвращается в переменную $data.

```
 if (false === ($data= $this->Cache_Get($sCacheKey, 'tmp'))) {
```

Для устранения ошибки переменная _$data_ в строке получения кэша переименована в _$sResult_
