### PR TITLE
Исправление виджета "прямой эфир"

### DIFF
--- a/common/classes/actions/ActionAjax.class.php
+++ b/common/classes/actions/ActionAjax.class.php
@@ -823,15 +823,12 @@ class ActionAjax extends Action {
      */
     protected function EventStreamComment() {
 
+        $oViewer = $this->Viewer_GetLocalViewer();
         if ($aComments = $this->Comment_GetCommentsOnline('topic', Config::Get('block.stream.row'))) {
-            $oViewer = $this->Viewer_GetLocalViewer();
             $oViewer->Assign('aComments', $aComments);
-            $sTextResult = $oViewer->FetchWidget('stream_comment.tpl');
-            $this->Viewer_AssignAjax('sText', $sTextResult);
-        } else {
-            $this->Message_AddErrorSingle($this->Lang_Get('block_stream_comments_no'), $this->Lang_Get('attention'));
-            return;
         }
+        $sTextResult = $oViewer->FetchWidget('stream_comment.tpl');
+        $this->Viewer_AssignAjax('sText', $sTextResult);
     }
 
     /**
@@ -841,17 +838,14 @@ class ActionAjax extends Action {
      */
     protected function EventStreamTopic() {
 
+        $oViewer = $this->Viewer_GetLocalViewer();
         if ($aTopics = $this->Topic_GetTopicsLast(Config::Get('block.stream.row'))) {
-            $oViewer = $this->Viewer_GetLocalViewer();
             $oViewer->Assign('aTopics', $aTopics);
             // LS-compatibility
             $oViewer->Assign('oTopics', $aTopics);
-            $sTextResult = $oViewer->FetchWidget('stream_topic.tpl');
-            $this->Viewer_AssignAjax('sText', $sTextResult);
-        } else {
-            $this->Message_AddErrorSingle($this->Lang_Get('block_stream_topics_no'), $this->Lang_Get('attention'));
-            return;
         }
+        $sTextResult = $oViewer->FetchWidget('stream_topic.tpl');
+        $this->Viewer_AssignAjax('sText', $sTextResult);
     }
 
     /**

--- a/common/templates/skin/start-kit/tpls/widgets/widget.stream_comment.tpl
+++ b/common/templates/skin/start-kit/tpls/widgets/widget.stream_comment.tpl
@@ -1,23 +1,27 @@
-<ul class="list-unstyled item-list">
-    {foreach $aComments as $oComment}
-        {$oUser=$oComment->getUser()}
-        {$oTopic=$oComment->getTarget()}
-        {$oBlog=$oTopic->getBlog()}
-        <li class="js-title-comment" title="{$oComment->getText()|strip_tags|trim|truncate:100:'...'|escape:'html'}">
-            <p>
-                <a href="{$oUser->getProfileUrl()}" class="author">{$oUser->getDisplayName()}</a>
-                <time datetime="{date_format date=$oComment->getDate() format='c'}" class="text-muted">
-                    · {date_format date=$oComment->getDate() hours_back="12" minutes_back="60" now="60" day="day H:i" format="j F Y, H:i"}
-                </time>
-            </p>
-            <a href="{if Config::Get('module.comment.nested_per_page')}{router page='comments'}{else}{$oTopic->getUrl()}#comment{/if}{$oComment->getId()}"
-               class="stream-topic">{$oTopic->getTitle()|escape:'html'}</a>
-            <span class="stream-topic text-danger">{$oTopic->getCountComment()}</span>
-        </li>
-    {/foreach}
-</ul>
+{if $aComments}
+    <ul class="list-unstyled item-list">
+        {foreach $aComments as $oComment}
+            {$oUser=$oComment->getUser()}
+            {$oTopic=$oComment->getTarget()}
+            {$oBlog=$oTopic->getBlog()}
+            <li class="js-title-comment" title="{$oComment->getText()|strip_tags|trim|truncate:100:'...'|escape:'html'}">
+                <p>
+                    <a href="{$oUser->getProfileUrl()}" class="author">{$oUser->getDisplayName()}</a>
+                    <time datetime="{date_format date=$oComment->getDate() format='c'}" class="text-muted">
+                        · {date_format date=$oComment->getDate() hours_back="12" minutes_back="60" now="60" day="day H:i" format="j F Y, H:i"}
+                    </time>
+                </p>
+                <a href="{if Config::Get('module.comment.nested_per_page')}{router page='comments'}{else}{$oTopic->getUrl()}#comment{/if}{$oComment->getId()}"
+                   class="stream-topic">{$oTopic->getTitle()|escape:'html'}</a>
+                <span class="stream-topic text-danger">{$oTopic->getCountComment()}</span>
+            </li>
+        {/foreach}
+    </ul>
+{else}
+    {$aLang.block_stream_comments_no}
+{/if}
 
 <footer class="small text-muted">
-    <a href="{router page='comments'}">{$aLang.block_stream_comments_all}</a> · <a
-            href="{router page='rss'}allcomments/">RSS</a>
+    <a href="{router page='comments'}">{$aLang.block_stream_comments_all}</a> ·
+    <a href="{router page='rss'}allcomments/">RSS</a>
 </footer>

--- a/common/templates/skin/start-kit/tpls/widgets/widget.stream_topic.tpl
+++ b/common/templates/skin/start-kit/tpls/widgets/widget.stream_topic.tpl
@@ -1,21 +1,25 @@
-<ul class="list-unstyled item-list">
-    {foreach $aTopics as $oTopic}
-        {$oUser=$oTopic->getUser()}
-        {$oBlog=$oTopic->getBlog()}
-        <li class="text-muted js-title-topic"
-            title="{$oTopic->getText()|strip_tags|trim|truncate:150:'...'|escape:'html'}">
-            <p>
-                <a href="{$oUser->getProfileUrl()}" class="author">{$oUser->getDisplayName()}</a>
-                <time datetime="{date_format date=$oTopic->getDate() format='c'}">
-                    · {date_format date=$oTopic->getDateAdd() hours_back="12" minutes_back="60" now="60" day="day H:i" format="j F Y, H:i"}
-                </time>
-            </p>
-            <a href="{$oBlog->getUrlFull()}" class="stream-topic blog-name">{$oBlog->getTitle()|escape:'html'}</a> &rarr;
-            <a href="{$oTopic->getUrl()}" class="stream-topic">{$oTopic->getTitle()|escape:'html'}</a>
-            <span class="stream-topic text-danger">{$oTopic->getCountComment()}</span>
-        </li>
-    {/foreach}
-</ul>
+{if $aTopics}
+    <ul class="list-unstyled item-list">
+        {foreach $aTopics as $oTopic}
+            {$oUser=$oTopic->getUser()}
+            {$oBlog=$oTopic->getBlog()}
+            <li class="text-muted js-title-topic"
+                title="{$oTopic->getText()|strip_tags|trim|truncate:150:'...'|escape:'html'}">
+                <p>
+                    <a href="{$oUser->getProfileUrl()}" class="author">{$oUser->getDisplayName()}</a>
+                    <time datetime="{date_format date=$oTopic->getDate() format='c'}">
+                        · {date_format date=$oTopic->getDateAdd() hours_back="12" minutes_back="60" now="60" day="day H:i" format="j F Y, H:i"}
+                    </time>
+                </p>
+                <a href="{$oBlog->getUrlFull()}" class="stream-topic blog-name">{$oBlog->getTitle()|escape:'html'}</a> &rarr;
+                <a href="{$oTopic->getUrl()}" class="stream-topic">{$oTopic->getTitle()|escape:'html'}</a>
+                <span class="stream-topic text-danger">{$oTopic->getCountComment()}</span>
+            </li>
+        {/foreach}
+    </ul>
+{else}
+    {$aLang.block_stream_topics_no}
+{/if}
 
 <footer class="small text-muted">
     <a href="{router page='index'}newall/">{$aLang.block_stream_topics_all}</a> ·


### PR DESCRIPTION
Исправляет виджет "прямой эфир", чтобы тот сообщал об отсутствии комментариев/постов внутри него самого, аналогично виджету тегов, а не всплывающим сообщением об ошибке при каждой загрузке. На рабочем сайте эти ошибки никогда не встретятся, но могут испортить впечатление при установке чистого движка.
