### PR TITLE
Сломанная верстка

### DIFF
--- a/common/templates/skin/start-kit/tpls/fields/field.tags-show.tpl
+++ b/common/templates/skin/start-kit/tpls/fields/field.tags-show.tpl
@@ -26,10 +26,8 @@
                     </li>
                 {/foreach}
             {/if}
-            <li class="topic-tags-edit js-favourite-tag-edit"
-                {if !$oFavourite}style="display:none;"{/if}>
-                <a href="#" onclick="return ls.favourite.showEditTags({$oTopic->getId()},'topic',this);"
-                   class="link-dotted">{$aLang.favourite_form_tags_button_show}</a>
+            <li class="topic-tags-edit js-favourite-tag-edit" {if !$oFavourite}style="display:none;"{/if}>
+                <a href="#" onclick="return ls.favourite.showEditTags({$oTopic->getId()},'topic',this);" class="link-dotted">{$aLang.favourite_form_tags_button_show}</a>
             </li>
         {/if}
     {/strip}


### PR DESCRIPTION
FF показывает битые теги с такими переводами строк, связано видимо с тем как обрабатывает этот код {strip}