### PR TITLE
Исправление: plugins.dat сохранялся не туда

### DIFF
--- a/engine/classes/modules/plugin/Plugin.class.php
+++ b/engine/classes/modules/plugin/Plugin.class.php
@@ -638,7 +638,7 @@ class ModulePlugin extends Module {
                 . (!empty($aPluginInfo['name']) ? ' ;' . $aPluginInfo['name'] : '');
         }
         // * Записываем данные в файл PLUGINS.DAT
-        $sFile = F::GetPluginsDatDir() . F::GetPluginsDatFile();
+        $sFile = F::GetPluginsDatFile();
         if (F::File_PutContents($sFile, implode(PHP_EOL, $aSaveData)) !== false) {
             return true;
         }


### PR DESCRIPTION
`F::GetPluginsDatFile()` уже возвращает вместе с путём, так что `F::GetPluginsDatDir()` добавляет этот путь еще раз, в итоге файл plugins.dat пишется не туда и вкл-выкл плагинов не работает.