### PR TITLE
Перенос хука comment_action

### DIFF
--- a/common/templates/skin/experience-simple/tpls/comments/comment.single.tpl
+++ b/common/templates/skin/experience-simple/tpls/comments/comment.single.tpl
@@ -114,7 +114,6 @@
                         </div>
                     {/if}
                     {$oComment->getText()}
-                    {hook run='comment_action' comment=$oComment}
                 </div>
 
                 <div class="comment-footer">
@@ -177,6 +176,7 @@
 
                             {/if}
                         {/if}
+                        {hook run='comment_action' comment=$oComment commentlist=$bCommentList}
                     </ul>
                 </div>
 


### PR DESCRIPTION
Хук comment_action в остальных шаблонах служит для добавления кнопок действия над комментарием. Тут он несколько не в том месте расположен