### PR TITLE
Фикс увеличения счетчика при подписке на блог на странице Блогов

### DIFF
--- a/common/plugins/rating/templates/skin/experience-simple/tpls/blog/blog.list.linexxs.inject.tpl
+++ b/common/plugins/rating/templates/skin/experience-simple/tpls/blog/blog.list.linexxs.inject.tpl
@@ -1,5 +1,5 @@
 {$oUserOwner=$oBlog->getOwner()}
-<td class="rating-value" id="blog_user_count_{$oBlog->getId()}">
+<td class="rating-value">
     {if Router::GetActionEvent()=='personal'}
         {$oUserOwner->getRating()|number_format:{Config::Get('view.rating_length')}}
     {else}

--- a/common/plugins/rating/templates/skin/experience/tpls/blog/blog.list.linexxs.inject.tpl
+++ b/common/plugins/rating/templates/skin/experience/tpls/blog/blog.list.linexxs.inject.tpl
@@ -1,5 +1,5 @@
 {$oUserOwner=$oBlog->getOwner()}
-<td rowspan="3" class="rating-value hidden-xs last-td" id="blog_user_count_{$oBlog->getId()}">
+<td rowspan="3" class="rating-value hidden-xs last-td">
     {if Router::GetActionEvent()=='personal'}
         {$oUserOwner->getRating()|number_format:{Config::Get('view.rating_length')}}
     {else}

--- a/common/templates/skin/experience-simple/tpls/commons/common.blog_list.tpl
+++ b/common/templates/skin/experience-simple/tpls/commons/common.blog_list.tpl
@@ -115,7 +115,7 @@
                     </td>
                     {/if}
                     {if Router::GetActionEvent()!='personal'}
-                        <td class="">
+                        <td id="blog_user_count_{$oBlog->getId()}">
                             {$oBlog->getCountUser()}
                         </td>
                     {/if}

--- a/common/templates/skin/experience/tpls/commons/common.blog_list.tpl
+++ b/common/templates/skin/experience/tpls/commons/common.blog_list.tpl
@@ -150,7 +150,7 @@
                         </td>
                     {/if}
                     {if Router::GetActionEvent()!='personal'}
-                        <td class="blog-peoples hidden-xxs last-td">
+                        <td id="blog_user_count_{$oBlog->getId()}" class="blog-peoples hidden-xxs last-td">
                             {$oBlog->getCountUser()}
                         </td>
                     {/if}


### PR DESCRIPTION
В шаблоне Experience из-за непривильно заданного id при подписке менялся не счетчик
подписчиков, а значение в колонке рейтинга.