### PR TITLE
Исправление переадресации

### DIFF
--- a/engine/include/Func.php
+++ b/engine/include/Func.php
@@ -1052,7 +1052,6 @@ class Func {
                     $sUrl = 'http://';
                 }
                 if (isset($_SERVER['SERVER_NAME'])) $sUrl .= $_SERVER['SERVER_NAME'];
-                print_r($_SERVER);
                 if (isset($_SERVER['SERVER_PORT']) && !in_array($_SERVER['SERVER_PORT'],array(80,443))) $sUrl .=  ':'.$_SERVER['SERVER_PORT'];
                 if (substr($sLocation, 0, 1) == '/') {
                     $sUrl .= $sLocation;

--- a/engine/include/Func.php
+++ b/engine/include/Func.php
@@ -1052,6 +1052,8 @@ class Func {
                     $sUrl = 'http://';
                 }
                 if (isset($_SERVER['SERVER_NAME'])) $sUrl .= $_SERVER['SERVER_NAME'];
+                print_r($_SERVER);
+                if (isset($_SERVER['SERVER_PORT']) && !in_array($_SERVER['SERVER_PORT'],array(80,443))) $sUrl .=  ':'.$_SERVER['SERVER_PORT'];
                 if (substr($sLocation, 0, 1) == '/') {
                     $sUrl .= $sLocation;
                 } else {


### PR DESCRIPTION
Неправильно срабатывает переадресация если указан нестандартный порт.
Для примера у себя для тестов поставил апач на 8080 порт и при входе на alto.local:8080 переадресовывает на alto.local/install/ что не есть правильно.
Заметил эту ошибку при первичной установке но, возможно, она будет наблюдаться и в других случаях