### PR TITLE
Исправления в light-версии шаблона start-kit

### DIFF
--- a/common/templates/skin/start-kit/themes/default/layouts/default_light.tpl
+++ b/common/templates/skin/start-kit/themes/default/layouts/default_light.tpl
@@ -24,11 +24,11 @@
     {$aHtmlHeadFiles.css}
 
     {if {Config::Get('view.theme')} == 'light'}
-        <link href='//fonts.googleapis.com/css?family=PT+Sans+Narrow:400,700&subset=latin,cyrillic'
-              rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Roboto:300,400,500,700&subset=latin,cyrillic' rel='stylesheet' type='text/css'>
     {/if}
 
-    <link href="{Config::Get('path.static.skin')}/images/favicon.ico?v1" rel="shortcut icon"/>
+    <link href="{asset file="img/favicon.png" theme=true}?v1" rel="shortcut icon"/> 
+
     <link rel="search" type="application/opensearchdescription+xml" href="{router page='search'}opensearch/"
           title="{Config::Get('view.name')}"/>
 


### PR DESCRIPTION
Сделано специально, что в default- и light- версиях шаблона используются разные шрифты? По идее нужно везде использовать одинаковые.

Поправил ссылку на favicon, чтобы не приходилось его держать сразу в нескольких папках.