### PR TITLE
Нельзя вмешиваться в содержимое URL - гиперссылку

### DIFF
--- a/common/classes/modules/user/entity/User.entity.class.php
+++ b/common/classes/modules/user/entity/User.entity.class.php
@@ -643,11 +643,11 @@ class ModuleUser_EntityUser extends Entity {
             if (!$sUrl) {
                 // Old version compatibility
                 $sUrl = $this->getProfileAvatar();
-                if ($sUrl) {
+                if ($sUrl[0] == '@') {
                     if ($xSize) {
                         $sUrl = E::ModuleUploader()->ResizeTargetImage($sUrl, $xSize);
                     }
-                } else {
+                } elseif (!$sUrl || $sUrl = '') {
                     $sUrl = $this->getDefaultAvatarUrl($xSize);
                 }
             }


### PR DESCRIPTION
В случае, когда в $sUrl (аватар пользователя) хранится не @uploads/... а URL (http://...) - содержимое $sUrl трогать нельзя. Необходимо возвращать его вверх в неизменном виде.

Конечно, идеально принимать решение вмешиваться/не вмешиваться в URL в одном месте (в E::ModuleUploader()->ResizeTargetImage($sUrl, $xSize)), но по ResizeTargetImage в коде ничего подходящего не нашел -(.