### PR TITLE
Изменил видимость метода getParamValue на public

### DIFF
--- a/common/classes/modules/mresource/entity/Mresource.entity.class.php
+++ b/common/classes/modules/mresource/entity/Mresource.entity.class.php
@@ -466,7 +466,7 @@ class ModuleMresource_EntityMresource extends Entity {
      *
      * @return null|mixed
      */
-    protected function getParamValue($sName) {
+    public function getParamValue($sName) {
 
         $this->extractParams();
         if (isset($this->aParams[$sName])) {


### PR DESCRIPTION
Есть публичный метод `getParams` который возвращает сырую сериализованную строку с `params`. Так почему бы не иметь публичным и `getParamValue`, который удобен для получения отдельных элементов `params`?

Например,  есть плагин, использующий функциональность дополнительных параметров в своих целях. Предоставленного api хватит, чтобы установить свои параметры, но для того, чтобы получить значение конкретного ключа, нужно либо наследоваться от класса `ModuleMresource_EntityMresource`, чтобы иметь доступ к protected методу `getParamValue`, либо не наследоваться, но воспользоваться публичным методом `getParams` и создать свой публичный аналог `getParamValue`.

Лень наследоваться, когда нет особых причин скрывать `getParamValue` же.