### PR TITLE
Fix: Из-за приведения к целому, при передаче значения размера от 2048…

### DIFF
--- a/engine/include/functions/Main.php
+++ b/engine/include/functions/Main.php
@@ -103,7 +103,7 @@ class AltoFunc_Main {
     }
 
     /**
-     * @param   float $nValue
+     * @param   int|float $nValue
      * @param   int   $nDecimal
      *
      * @return  string
@@ -112,7 +112,7 @@ class AltoFunc_Main {
 
         $aUnits = self::$sMemSizeUnits;
         $nIndex = 0;
-        $nResult = intval($nValue);
+        $nResult = $nValue;
         while ($nResult >= 1024) {
             $nIndex += 1;
             $nResult = $nResult / 1024;
@@ -133,7 +133,7 @@ class AltoFunc_Main {
      *
      * @param $sNum
      *
-     * @return int|number
+     * @return int|float
      */
     static public function MemSize2Int($sNum) {
 
@@ -145,7 +145,7 @@ class AltoFunc_Main {
                 $nValue *= pow(1024, $nIdx);
             }
         }
-        return intval($nValue);
+        return $nValue;
     }
 
     /**


### PR DESCRIPTION
…Mb (на 32-разрядном пхп), происходит переполнение типа int и функции возвращают неправильный результат.
До фикса: http://codepad.org/8fY1wkBf, после: http://codepad.org/KxHeHLwx