### PR TITLE
Фикс съезжающих влево комментариев после достижения предельной глубины

### DIFF
--- a/common/templates/skin/experience-simple/tpls/comments/comment.single.tpl
+++ b/common/templates/skin/experience-simple/tpls/comments/comment.single.tpl
@@ -23,7 +23,7 @@
         {$sCommentClass = "$sCommentClass comment-new"}
     {/if}
 {/if}
-<div id="comment_id_{$oComment->getId()}"  data-level="{$oComment->getLevel() + 1}"  class="comment comment-level comment-level-{$oComment->getLevel() + 1} {$sCommentClass}">
+<div id="comment_id_{$oComment->getId()}"  data-level="{$cmtlevel + 1}"  class="comment comment-level comment-level-{$cmtlevel + 1} {$sCommentClass}">
     <div class="panel panel-default comment">
         <div class="panel-body">
         {if !$oComment->getDelete() OR $bOneComment OR E::IsAdmin() OR $oComment->isDeletable()}


### PR DESCRIPTION
Переменная из родительского шаблона вывода дерева комментов, там она участвует в математике и ограничивается по росту при достижении предела глубины дерева комментариев. Предыдущий вариант растет до бесконечности, а количество прописанных стилей притом вполне себе конечно.

Фикс проверен, рабочий.