### PR TITLE
Фикс работы кнопки подписки на отписку плюс визуальный фикс

### DIFF
--- a/common/templates/frontend/libs/js/engine/user.js
+++ b/common/templates/frontend/libs/js/engine/user.js
@@ -212,10 +212,10 @@ ls.user = (function ($) {
         button = $(button);
         if (button.hasClass('followed')) {
             ls.stream.unsubscribe(iUserId);
-            button.toggleClass('followed').text(ls.lang.get('profile_user_follow'));
+            button.toggleClass('followed').text(ls.lang.get('profile_user_follow')).prepend('<i class="fa fa-star-o"></i>&nbsp;');
         } else {
             ls.stream.subscribe(iUserId);
-            button.toggleClass('followed').text(ls.lang.get('profile_user_unfollow'));
+            button.toggleClass('followed').text(ls.lang.get('profile_user_unfollow')).prepend('<i class="fa fa-star-o"></i>&nbsp;');
         }
         return false;
     };

--- a/common/templates/frontend/ls/js/user.js
+++ b/common/templates/frontend/ls/js/user.js
@@ -578,10 +578,10 @@ ls.user = (function ($) {
     this.followToggle = function (obj, iUserId) {
         if ($(obj).hasClass('followed')) {
             ls.stream.unsubscribe(iUserId);
-            $(obj).toggleClass('followed').text(ls.lang.get('profile_user_follow'));
+            $(obj).toggleClass('followed').text(ls.lang.get('profile_user_follow')).prepend('<i class="fa fa-star-o"></i>&nbsp;');
         } else {
             ls.stream.subscribe(iUserId);
-            $(obj).toggleClass('followed').text(ls.lang.get('profile_user_unfollow'));
+            $(obj).toggleClass('followed').text(ls.lang.get('profile_user_unfollow')).prepend('<i class="fa fa-star-o"></i>&nbsp;');
         }
         return false;
     };

--- a/common/templates/skin/experience-simple/tpls/actions/profile/action.profile.pre.tpl
+++ b/common/templates/skin/experience-simple/tpls/actions/profile/action.profile.pre.tpl
@@ -157,7 +157,7 @@
                 </script>
                 <a href="#"
                    onclick="ls.user.followToggle(this, {$oUserProfile->getId()}); return false;"
-                   class="link link-light-gray link-clear link-lead"><i class="fa fa-star-o"></i>
+                   class="link link-light-gray link-clear link-lead {if $oUserProfile->isFollow()}followed{/if}"><i class="fa fa-star-o"></i>
                     {if $oUserProfile->isFollow()}{$aLang.profile_user_unfollow}{else}{$aLang.profile_user_follow}{/if}
                 </a>
             </li>

--- a/common/templates/skin/experience-simple/tpls/api/user/id/info/api.user.id.info.default.tpl
+++ b/common/templates/skin/experience-simple/tpls/api/user/id/info/api.user.id.info.default.tpl
@@ -30,7 +30,7 @@
                     </script>
                     <a href="#"
                        onclick="ls.user.followToggle(this, {$oUser->getId()}); return false;"
-                       class="link link-light-gray link-clear link-lead"><i class="fa fa-star-o"></i>
+                       class="link link-light-gray link-clear link-lead {if $oUser->isFollow()}followed{/if}"><i class="fa fa-star-o"></i>
                         {if $oUser->isFollow()}{E::ModuleLang()->Get('profile_user_unfollow')}{else}{E::ModuleLang()->Get('profile_user_follow')}{/if}
                     </a>
                 </li>


### PR DESCRIPTION
Кнопка подписки в шаблоне симпл не работала с первого раза на отписку из-за недостающего класса, на базе которого скрипт определяет, подписываться ему или отписываться.
Визуальный фикс заключается в том, что при активации js-скрипта пропадал значок звездочки, что логично, т.к. команда .text в jQuery заменяет все целиком, не делая исключений. Исправлено добавлением .prepend.