### PR TITLE
Fix/generator (движок не мог найти классы модуля из-за дефисов в имени папки модуля, ибо в системе имя папки получалось преобразованием strtolower('FooBarLol'))

### DIFF
--- a/common/console/commands/CmdPlugin.class.php
+++ b/common/console/commands/CmdPlugin.class.php
@@ -20,39 +20,44 @@ EOD;
         include_once '../../../engine/include/functions/Main.php';
 
         // Передано ли имя нового плагина
-        if(!isset($aArgs[0]))
+        if (!isset($aArgs[0])) {
             die("The plugin name is not specified.\n");
+        }
 
         $this->_name = $aArgs[0];
 
-        $path=strtr($this->_name, '/\\', DIRECTORY_SEPARATOR);
-        $path=Config::Get('path.root.server').'/common/plugins/'.$path;
-        if(strpos($path,DIRECTORY_SEPARATOR)===false)
-            $path='.'.DIRECTORY_SEPARATOR.$path;
+        $path = strtr($this->_name, '/\\', DIRECTORY_SEPARATOR);
+        $path = Config::Get('path.root.server') . '/common/plugins/' . $path;
+        if (strpos($path, DIRECTORY_SEPARATOR) === false) {
+            $path = '.' . DIRECTORY_SEPARATOR . $path;
+        }
 
-        $dir=rtrim(realpath(dirname($path)),'\\/');
-        if($dir===false || !is_dir($dir))
+        $dir = rtrim(realpath(dirname($path)), '\\/');
+        if ($dir === false || !is_dir($dir)) {
             die("The directory '$path' is not valid. Please make sure the parent directory exists.\n");
+        }
 
-        $sourceDir=realpath(dirname(__FILE__).'/../protected/plugin');
-        if($sourceDir===false)
+        $sourceDir = realpath(dirname(__FILE__) . '/../protected/plugin');
+        if ($sourceDir === false) {
             die("\nUnable to locate the source directory.\n");
+        }
 
         // Создаем массив файлов для функции копирования
-        $aList=$this->buildFileList($sourceDir,$path);
+        $aList = $this->buildFileList($sourceDir, $path);
 
         // Парсим имена плагинов и пересоздаем массив
-        foreach($aList as $sName=>$aFile) {
-            $sTarget=str_replace('Example', AltoFunc_Main::StrCamelize($this->_name),$aFile['target']);
-            $sTarget=str_replace('example',strtolower($this->_name),$sTarget);
-            $sNewName=str_replace('Example', AltoFunc_Main::StrCamelize($this->_name),$sName);
-            $sNewName=str_replace('example', AltoFunc_Main::StrUnderscore(AltoFunc_Main::StrCamelize($this->_name)),$sNewName);
-            if($sName != $sNewName)
+        foreach ($aList as $sName => $aFile) {
+            $sTarget  = str_replace('Example', AltoFunc_Main::StrCamelize($this->_name), $aFile['target']);
+            $sTarget  = str_replace('example', strtolower($this->_name), $sTarget);
+            $sNewName = str_replace('Example', AltoFunc_Main::StrCamelize($this->_name), $sName);
+            $sNewName = str_replace('example', AltoFunc_Main::StrUnderscore(AltoFunc_Main::StrCamelize($this->_name)), $sNewName);
+            if ($sName != $sNewName) {
                 unset($aList[$sName]);
+            }
 
-            $aFile['target'] = $sTarget;
-            $aList[$sNewName]=$aFile;
-            $aList[$sNewName]['callback']=array($this,'generatePlugin');
+            $aFile['target']              = $sTarget;
+            $aList[$sNewName]             = $aFile;
+            $aList[$sNewName]['callback'] = array($this, 'generatePlugin');
         }
 
         // Копируем файлы
@@ -63,14 +68,15 @@ EOD;
     /*
      * Парсер выражений в исходниках эталонного плагина
      */
-    public function generatePlugin($source,$params) {
+    public function generatePlugin($source, $params) {
 
-        $content=file_get_contents($source);
+        $content = file_get_contents($source);
         if (basename($source) == 'plugin.xml') {
             $content = str_replace('<id>example</id>', '<id>' . AltoFunc_Main::StrUnderscore(AltoFunc_Main::StrCamelize($this->_name)) . '</id>', $content);
         }
         $content = str_replace('Example', AltoFunc_Main::StrCamelize($this->_name), $content);
         $content = str_replace('example', strtolower($this->_name), $content);
+
         return $content;
     }
 }

--- a/common/console/commands/CmdPlugin.class.php
+++ b/common/console/commands/CmdPlugin.class.php
@@ -46,7 +46,7 @@ EOD;
             $sTarget=str_replace('Example', AltoFunc_Main::StrCamelize($this->_name),$aFile['target']);
             $sTarget=str_replace('example',strtolower($this->_name),$sTarget);
             $sNewName=str_replace('Example', AltoFunc_Main::StrCamelize($this->_name),$sName);
-            $sNewName=str_replace('example',strtolower($this->_name),$sNewName);
+            $sNewName=str_replace('example', AltoFunc_Main::StrUnderscore(AltoFunc_Main::StrCamelize($this->_name)),$sNewName);
             if($sName != $sNewName)
                 unset($aList[$sName]);
 

--- a/common/console/ls.php
+++ b/common/console/ls.php
@@ -1,14 +1,14 @@
 <?php
 
 // Для эмуляции работы, т.к используется в конфиге
-$_SERVER['HTTP_HOST']='localhost';
+$_SERVER['HTTP_HOST'] = 'localhost';
 
 defined('ALTO_DIR') || define('ALTO_DIR', dirname(realpath((dirname(__FILE__)) . "/../")));
 set_include_path(get_include_path() . PATH_SEPARATOR . ALTO_DIR);
 chdir(ALTO_DIR);
 
 require_once(ALTO_DIR . '/engine/loader.php');
-require_once(dirname(__FILE__).'/lsc.php');
+require_once(dirname(__FILE__) . '/lsc.php');
 
 
 LSC::Start();

--- a/engine/classes/core/Engine.class.php
+++ b/engine/classes/core/Engine.class.php
@@ -1241,7 +1241,7 @@ class Engine extends LsObject {
             if ($aInfo[self::CI_PLUGIN]) {
                 // Сущность модуля плагина
                 $sFile = 'plugins/' . $sPluginDir
-                    . '/classes/modules/' . strtolower($aInfo[self::CI_MODULE])
+                    . '/classes/modules/' . F::StrUnderscore($aInfo[self::CI_MODULE])
                     . '/entity/' . $aInfo[self::CI_ENTITY] . '.entity.class.php';
             } else {
                 // Сущность модуля ядра
@@ -1253,7 +1253,7 @@ class Engine extends LsObject {
             if ($aInfo[self::CI_PLUGIN]) {
                 // Маппер модуля плагина
                 $sFile = 'plugins/' . $sPluginDir
-                    . '/classes/modules/' . strtolower($aInfo[self::CI_MODULE])
+                    . '/classes/modules/' . F::StrUnderscore($aInfo[self::CI_MODULE])
                     . '/mapper/' . $aInfo[self::CI_MAPPER] . '.mapper.class.php';
             } else {
                 // Маппер модуля ядра
@@ -1275,7 +1275,7 @@ class Engine extends LsObject {
             if ($aInfo[self::CI_PLUGIN]) {
                 // Модуль плагина
                 $sFile = 'plugins/' . $sPluginDir
-                    . '/classes/modules/' . strtolower($aInfo[self::CI_MODULE])
+                    . '/classes/modules/' . F::StrUnderscore($aInfo[self::CI_MODULE])
                     . '/' . $aInfo[self::CI_MODULE] . '.class.php';
                 ;
             } else {


### PR DESCRIPTION
Когда вносил изменения в генератор, упустил из виду загрузчик системы. Теперь генератор именует папки модулей с подчёркиванием. То есть, если имя плагина `foo-bar-lol`, то папка модуля будет `foo_bar_lol`. В системе, имя модуля `FooBarLol` [конвертируется](https://github.com/shtrih/altocms/blob/9d9e8e096b81fe974c98e4e95c7c0e09b762602d/engine/classes/core/Engine.class.php#L1244) в `foo_bar_lol`, класс модуля найдётся успешно.
То же самое можно, наверное, сделать для [модулей ядра](https://github.com/shtrih/altocms/blob/9d9e8e096b81fe974c98e4e95c7c0e09b762602d/engine/classes/core/Engine.class.php#L1248) для единообразия, но я пока оставил по-старому.