### PR TITLE
Удание тега twitter:card

### DIFF
--- a/common/classes/actions/ActionBlog.class.php
+++ b/common/classes/actions/ActionBlog.class.php
@@ -993,13 +993,6 @@ class ActionBlog extends Action {
                     'content' => 'article',
                 ),
             );
-            $aHeadTags[] = array(
-                'meta',
-                array(
-                    'name' => 'twitter:card',
-                    'content' => 'summary',
-                ),
-            );
             if ($oTopic->getPreviewImageUrl()) {
                 $aHeadTags[] = array(
                     'meta',


### PR DESCRIPTION
В зависимости от типа топика пользователь, возможно, захочет переопределить вид карточки, показываемой в Twitter. Сейчас тип жестко зашит в движке, и хуками его исправить нельзя, - они вызываются раньше.